### PR TITLE
Add installation guides for Linux, OS X

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -15,8 +15,8 @@
 
 - title: Git på OS X
   slug: guider/git-osx.html
-  description: Hvem vet hvordan dette fungerer?
-  image: http://meskellmedicalsupplies.com/communities/8/000/000/214/258//images/7143358.png
+  description: Dette er superenkelt!
+  image: http://blog.digitaltavern.com/wp-content/uploads/2014/12/Yosemite-OS-X-Mac.jpg
 
 - title: Git cheat sheet
   slug: guider/git-cheat-sheet.html

--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -8,6 +8,16 @@
   description: Det enkleste er å installere linux
   image: http://akroot313.andrewkeir313.netdna-cdn.com/wp-content/uploads/windows-8-logo-excerpt.jpg
 
+- title: Git på Linux
+  slug: guider/git-linux.html
+  description: Det er ganske enkelt å installere
+  image: http://upload.wikimedia.org/wikipedia/commons/thumb/3/35/Tux.svg/2000px-Tux.svg.png
+
+- title: Git på OS X
+  slug: guider/git-osx.html
+  description: Hvem vet hvordan dette fungerer?
+  image: http://meskellmedicalsupplies.com/communities/8/000/000/214/258//images/7143358.png
+
 - title: Git cheat sheet
   slug: guider/git-cheat-sheet.html
   description: Enkel oversikt over de viktigste kommandoene

--- a/guider/git-linux.md
+++ b/guider/git-linux.md
@@ -1,0 +1,6 @@
+---
+layout: guide
+---
+
+# Git på Linux
+Installer git via pakkesystemet ditt, typisk `sudo apt-get install git` hvis du bruker Ubuntu, eller tilsvarende for andre Linux-distribusjoner.

--- a/guider/git-osx.md
+++ b/guider/git-osx.md
@@ -1,0 +1,6 @@
+---
+layout: guide
+---
+
+# Git på OS X
+???

--- a/guider/git-osx.md
+++ b/guider/git-osx.md
@@ -3,4 +3,8 @@ layout: guide
 ---
 
 # Git på OS X
-???
+
+Git på OS X blir installert i command line tools-pakken din fra Apple. Hvis du ikke har installert denne skriv `xcode-select --install` i Terminalen din.
+Terminalen finner du under Applikasjoner -> Verktøy.
+
+Hvis du bruker Homebrew som pakkebehandler kan du skrive `brew install git`.


### PR DESCRIPTION
The OS X guide is just a placeholder. Someone should probably replace it
with something better.
