### PR TITLE
Remove blank baseurl param to server in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: run
 run:
-	bundle exec jekyll serve --watch --baseurl ''
+	bundle exec jekyll serve --watch
 
 .PHONY: build
 build:


### PR DESCRIPTION
Serving without the baseurl as /git/ breaks css linking in guides, and
maybe other things. When this lands, running `make` locally will host
the site at `http://localhost:4000/git/` rather than
`http://localhost:4000/`.
